### PR TITLE
Added onDispose Functionality and Modified deps Type to Array in useEffect

### DIFF
--- a/react/src/main/java/me/pavi2410/useCompose/react/hooks.kt
+++ b/react/src/main/java/me/pavi2410/useCompose/react/hooks.kt
@@ -24,8 +24,29 @@ fun <T> useState(defaultValue: T): Pair<T, (T) -> Unit> {
  */
 @SuppressLint("ComposableNaming")
 @Composable
-fun useEffect(vararg deps: Any, block: suspend CoroutineScope.() -> Unit) {
-    LaunchedEffect(keys = deps, block = block)
+fun useEffect(deps: Array<Any> = emptyArray(),
+              onEffect: suspend () -> Unit,
+              onDispose: () -> Unit = {}) {
+
+    val currentOnEffect = rememberUpdatedState(onEffect)
+    val currentOnDispose = rememberUpdatedState(onDispose)
+
+    if (deps.isEmpty()) {
+
+        LaunchedEffect(Unit) {
+            currentOnEffect.value()
+        }
+        DisposableEffect(Unit) {
+            onDispose { currentOnDispose.value() }
+        }
+    }else {
+        LaunchedEffect(deps) {
+            currentOnEffect.value()
+        }
+        DisposableEffect(deps) {
+            onDispose { currentOnDispose.value() }
+        }
+    }
 }
 
 @Suppress("PropertyName")


### PR DESCRIPTION
Hello ~,

I needed an onDispose functionality within useEffect, so I've added it. Additionally, I have changed the type of deps to an array.

I would appreciate it if you could review them.


```kotlin

// example

    /*
    useEffect(()=>{
        console.log("Call once")
    },[])
    */
    useEffect(onEffect = {
        println("Call once")
    })

    /*
    useEffect(()=>{
        console.log("Call once")
        return  () => {
            console.log("onDispose")
        }
    },[])
    */
    useEffect(onEffect = {
            println("Call once")
        }, onDispose = {
            println("onDispose")
        }
    )

    /*
    useEffect(()=>{
        console.log("Call when the value of isOn changes")
        return  () => {
            console.log("onDispose")
        }
    },[isOn, "SOME" ])
    */
    useEffect(arrayOf(isOn,"SOME"),
        onEffect =  {
            println("Call when the value of isOn changes  [isOn] $isOn")
        }, onDispose = {
            println("onDispose")
        }
    )
```